### PR TITLE
fix: escape useId() output in CSS selector for React 18 compatibility

### DIFF
--- a/src/Email.tsx
+++ b/src/Email.tsx
@@ -61,7 +61,7 @@ function ObfuscateEmail({ email }: { email: string }) {
 		<>
 			<style>
 				{`
-					#${id}::after {
+					#${id.replace(/[^\w-]/g, "\\$&")}::after {
 						content: "@";
 					}
 				`}


### PR DESCRIPTION
### Problem

`ObfuscateEmail` uses `useId()` to generate a unique ID for the `<span>`, then inserts it directly into a `<style>` tag as a CSS ID selector:

```ts
`#${id}::after { content: "@"; }`
```

In React 18, `useId()` generates IDs in the format `:r3R0:`. While this is a perfectly valid HTML `id` attribute value, the leading `:` is a special character in CSS (used for pseudo-classes). The selector `#:r3R0:::after` is therefore **invalid** — the browser ignores the rule entirely and the `@` sign is never rendered.

### Why not `CSS.escape()`?

The obvious fix is `CSS.escape(id)`, which is the browser-native API for exactly this purpose. However, `CSS` is a browser-only global — it does not exist in Node.js. Using it causes a `ReferenceError` during server-side rendering (e.g. with Astro, Next.js App Router with SSR, etc.):

```
ReferenceError: CSS is not defined
```

### Fix

Escape non-word, non-hyphen characters inline, which is the correct subset of the CSS identifier escaping algorithm ([CSSOM spec](https://drafts.csswg.org/cssom/#serialize-an-identifier)) for ASCII identifiers as produced by React's `useId()`:

```ts
`#${id.replace(/[^\w-]/g, "\\$&")}::after {`
```

This works in both browser and Node.js SSR environments and correctly escapes `:r3R0:` → `\:r3R0\:`, producing the valid selector `#\:r3R0\:::after`.

### Affected environments

- Any SSR framework (Astro, Next.js, Remix, …) using React 18+
- Client-only apps using React 18+ (selector silently broken, `@` not rendered)